### PR TITLE
Properly add backup group in order to seperate backups

### DIFF
--- a/services/storage/longhorn/recurringJobs/backup.yaml
+++ b/services/storage/longhorn/recurringJobs/backup.yaml
@@ -7,7 +7,7 @@ spec:
   concurrency: 1
   cron: 0 2 * * */3
   groups:
-  - default
+  - backup
   labels: {}
   name: cf-backup
   retain: 3

--- a/services/storage/longhorn/storageClasses/longhorn-locality-retain.yaml
+++ b/services/storage/longhorn/storageClasses/longhorn-locality-retain.yaml
@@ -15,4 +15,4 @@ parameters:
   replicaAutoBalance: "least-effort"
 #  diskSelector: "ssd,fast"
 #  nodeSelector: "storage,fast"
-  recurringJobSelector: '[{"name":"default", "isGroup":true},{"name":"backup", "isGroup":false}]'
+  recurringJobSelector: '[{"name":"default", "isGroup":true},{"name":"backup", "isGroup":true}]'

--- a/services/storage/longhorn/storageClasses/longhorn-locality.yaml
+++ b/services/storage/longhorn/storageClasses/longhorn-locality.yaml
@@ -15,4 +15,4 @@ parameters:
   replicaAutoBalance: "least-effort"
 #  diskSelector: "ssd,fast"
 #  nodeSelector: "storage,fast"
-  recurringJobSelector: '[{"name":"default", "isGroup":true},{"name":"backup", "isGroup":false}]'
+  recurringJobSelector: '[{"name":"default", "isGroup":true},{"name":"backup", "isGroup":true}]'

--- a/services/storage/longhorn/storageClasses/longhorn-retain.yaml
+++ b/services/storage/longhorn/storageClasses/longhorn-retain.yaml
@@ -15,4 +15,4 @@ parameters:
   replicaAutoBalance: "least-effort"
 #  diskSelector: "ssd,fast"
 #  nodeSelector: "storage,fast"
-  recurringJobSelector: '[{"name":"default", "isGroup":true},{"name":"backup", "isGroup":false}]'
+  recurringJobSelector: '[{"name":"default", "isGroup":true},{"name":"backup", "isGroup":true}]'

--- a/services/storage/longhorn/storageClasses/longhorn-strict-local-retain.yaml
+++ b/services/storage/longhorn/storageClasses/longhorn-strict-local-retain.yaml
@@ -15,4 +15,4 @@ parameters:
   replicaAutoBalance: "ignored"
 #  diskSelector: "ssd,fast"
 #  nodeSelector: "storage,fast"
-  recurringJobSelector: '[{"name":"default", "isGroup":true},{"name":"backup", "isGroup":false}]'
+  recurringJobSelector: '[{"name":"default", "isGroup":true},{"name":"backup", "isGroup":true}]'

--- a/services/storage/longhorn/storageClasses/longhorn-strict-local.yaml
+++ b/services/storage/longhorn/storageClasses/longhorn-strict-local.yaml
@@ -15,4 +15,4 @@ parameters:
   replicaAutoBalance: "ignored"
 #  diskSelector: "ssd,fast"
 #  nodeSelector: "storage,fast"
-  recurringJobSelector: '[{"name":"default", "isGroup":true},{"name":"backup", "isGroup":false}]'
+  recurringJobSelector: '[{"name":"default", "isGroup":true},{"name":"backup", "isGroup":true}]'


### PR DESCRIPTION
This might need more testing before applying it to the cluster since I need to see if forcing the change might work and not cause instability.  