### PR TITLE
Add hard drive support

### DIFF
--- a/ansible-inventory.example.ini
+++ b/ansible-inventory.example.ini
@@ -18,12 +18,16 @@
 # if you wish, you can specify an alias for a node, or you can just specify
 # the ip address as shown below:
 
-# you need to always define the ansible_ssh_host and ansible_ssh_private_key because they will be changed automatically
+# you need to always define the ansible_ssh_host and ansible_ssh_private_key_file because they will be changed automatically
 # you maybe to need to define the external interface (that will be given to the router, alongside the whole PCI device). 
 
 
-#node1 ansible_ssh_host=10.0.0.2 ansible_ssh_private_key=/path/to/private_key
-#node1 ansible_ssh_host=10.0.0.2 ansible_ssh_private_key=/path/to/private_key external_interface=enp1f0
+#node1 ansible_ssh_host=10.0.0.2 ansible_ssh_private_key_file=/path/to/private_key
+#node1 ansible_ssh_host=10.0.0.2 ansible_ssh_private_key_file=/path/to/private_key external_interface=enp1f0
+
+
+#any node can be used to setup zfs pools
+#node2 ansible_ssh_host=192.168.121.184 ansible_user=ni ansible_ssh_private_key_file=node/bootstrap_key storage=true
 
 
 [workers]

--- a/maintenance/update-all-playbook-no-restart.yaml
+++ b/maintenance/update-all-playbook-no-restart.yaml
@@ -1,0 +1,23 @@
+---
+
+- name: Update all nodes
+  hosts: nodes
+  become: true
+  tasks:
+    - name: Update nodes using DNF # noqa: package-latest
+      ansible.builtin.dnf:
+        name: "*"
+        update_cache: true
+        update_only: true
+        state: latest
+
+- name: Update all routers
+  hosts: routers
+  become: true
+  tasks:
+    - name: Update nodes using APT
+      ansible.builtin.apt:
+        name: "*"
+        update_cache: true
+        only_upgrade: true
+        state: latest

--- a/node/add-zfs-to-storage-node.yaml
+++ b/node/add-zfs-to-storage-node.yaml
@@ -1,0 +1,103 @@
+---
+- name: Add zfs to storage nodes
+  hosts: all
+  become: true
+  vars:
+    zfs_pool_name: "niployments-hard-storage"
+    zfs_pool_mountpoint: "/mnt/hard-storage"
+    zfs_pool_state: present
+    zfs_pool_mode: "raidz"
+
+  tasks:
+    - name: Only run play if storage is not enabled
+      when: hostvars[inventory_hostname]['storage'] is defined and hostvars[inventory_hostname]['storage'] == "true"
+      block:
+        - name: Get stoarge definitions
+          ansible.builtin.include_vars:
+            file: storage-defs.json
+            name: storage_definitions
+        - name: Use storage definition for node
+          ansible.builtin.set_fact:
+            zfs_pool_devices: "{{ storage_definitions[inventory_hostname] }}"
+        - name: Enable EPEL repository
+          ansible.builtin.yum:
+            name: epel-release
+            state: present
+        - name: Add ZFS GPG key
+          ansible.builtin.rpm_key:
+            state: present
+            key: https://raw.githubusercontent.com/zfsonlinux/zfsonlinux.github.com/master/zfs-release/RPM-GPG-KEY-openzfs-key2
+        - name: Install DKMS manually
+          ansible.builtin.yum:
+            name: dkms
+            state: present
+        - name: Install zfs repo
+          ansible.builtin.yum:
+            name: "https://zfsonlinux.org/epel/zfs-release-2-3.el9.noarch.rpm"
+            state: present
+        - name: Install ZFS
+          ansible.builtin.dnf:
+            name:
+              - zfs
+              - zfs-dkms
+              - kernel-devel
+            state: present
+        - name: Install dkms modules
+          ansible.builtin.command: dkms autoinstall
+          changed_when: true
+        - name: Load ZFS kernel module
+          ansible.builtin.command: modprobe zfs
+          failed_when: false
+          ignore_errors: true
+        - name: Check ZFS pool existance
+          ansible.builtin.command: zpool list -Ho name {{ zfs_pool_name }}
+          register: result_pool_list
+          ignore_errors: true
+          failed_when: false
+
+        - name: Create ZFS pool
+          ansible.builtin.command: >-
+            zpool create
+            {{ '-m ' + zfs_pool_mountpoint if zfs_pool_mountpoint else '' }}
+            {{ zfs_pool_name }}
+            {{ zfs_pool_mode if zfs_pool_mode else '' }}
+            {{ zfs_pool_devices | join(' ') }}
+          when:
+            - zfs_pool_state | default('present') == 'present'
+            - result_pool_list.rc == 1
+        - name: Install NFS utilities
+          ansible.builtin.dnf:
+            name: nfs-utils
+            state: present
+
+        - name: Force nfs version 4
+          ansible.builtin.lineinfile:
+            path: /etc/nfsmount.conf
+            regexp: "^# Nfsvers=4"
+            line: "Nfsvers=4"
+        - name: Enable and start the NFS server service
+          ansible.builtin.systemd:
+            name: nfs-server
+            enabled: true
+            state: started
+
+        - name: Create export directory
+          ansible.builtin.file:
+            path: "{{ zfs_pool_mountpoint }}/shared_dir"
+            state: directory
+            mode: '0755'
+
+        - name: Set SELinux context for the export directory
+          ansible.builtin.command: chcon -t nfs_t {{ zfs_pool_mountpoint }}/shared_dir
+          args:
+            creates: /export/shared_dir
+
+        - name: Configure NFS exports
+          ansible.builtin.copy:
+            dest: /etc/exports
+            content: "{{ zfs_pool_mountpoint }}/shared_dir *(rw,sync,no_root_squash,no_subtree_check)\n"
+            mode: "0644"
+
+        - name: Export NFS shares
+          ansible.builtin.command: exportfs -r
+          changed_when: true

--- a/node/vars/storage-defs.json
+++ b/node/vars/storage-defs.json
@@ -1,0 +1,7 @@
+{
+    "cluster2": [
+        "/dev/disk/by-id/ata-ST2000DM008-2UB102_WFL7F5R8",
+        "/dev/disk/by-id/ata-ST2000DM008-2UB102_WFL7F74S",
+        "/dev/disk/by-id/ata-ST2000DM008-2UB102_WFL7HRE3"
+    ]
+}


### PR DESCRIPTION
In niployments we now gain the capability of adding new storage nodes that use zfs and nfs in the background. This also deploys `nfs-subdir-external-provisioner` to ensure that it is exported to k8s