### PR TITLE
fix: Traefik in kind cluster

### DIFF
--- a/dev/setup-kind-cluster.sh
+++ b/dev/setup-kind-cluster.sh
@@ -95,7 +95,7 @@ echo "Waiting for traefik deployment..."
 $KUBECTL_EXECUTABLE wait --for=condition=available --timeout=180s \
   deployment/traefik -n kube-system
 
-$(dirname $0)/../services/cert-manager/deploy-dev.sh
+bash $(dirname $0)/../services/cert-manager/deploy-dev.sh
 
 echo "Waiting for cert-manager to be ready..."
 $KUBECTL_EXECUTABLE wait --for=condition=available --timeout=180s \

--- a/dev/setup-kind-cluster.sh
+++ b/dev/setup-kind-cluster.sh
@@ -4,7 +4,7 @@ KIND_EXECUTABLE=kind
 KUBECTL_EXECUTABLE=kubectl
 
 CILIUM_EXECUTABLE=cilium-cli
-command -v $CILIUM_EXECUTABLE >/dev/null 2>&1 
+command -v $CILIUM_EXECUTABLE >/dev/null 2>&1
 if [ $? -ne 0 ]; then
   echo "Did not find cilium-cli, trying cilium..."
   CILIUM_EXECUTABLE=cilium
@@ -85,6 +85,26 @@ $HELM_EXECUTABLE upgrade --install traefik traefik/traefik \
   --values $(dirname $0)/../services/traefik/values-dev.yaml \
   --namespace kube-system
 
+echo "Waiting for traefik LoadBalancer IP..."
+LB_IP=$($KUBECTL_EXECUTABLE wait --for=jsonpath='{.status.loadBalancer.ingress[0].ip}' \
+  --timeout=120s svc/traefik -n kube-system \
+  -o jsonpath='{.status.loadBalancer.ingress[0].ip}') \
+  || { echo "traefik did not get a LoadBalancer IP" >&2; exit 1; }
+
+echo "Waiting for traefik deployment..."
+$KUBECTL_EXECUTABLE wait --for=condition=available --timeout=180s \
+  deployment/traefik -n kube-system
+
 $(dirname $0)/../services/cert-manager/deploy-dev.sh
 
+echo "Waiting for cert-manager to be ready..."
+$KUBECTL_EXECUTABLE wait --for=condition=available --timeout=180s \
+  deployment/cert-manager -n cert-manager
+
 $KUBECTL_EXECUTABLE apply -f $(dirname "$0")/../services/storage/longhorn/storageClasses/fakeDevClasses
+
+cat <<EOF
+Dev cluster is ready.
+- traefik LoadBalancer IP: $LB_IP
+- To reach services by hostname, run: sudo $PWD/dev/update-dev-hosts.sh
+EOF

--- a/dev/update-dev-hosts.sh
+++ b/dev/update-dev-hosts.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+# Map niployments dev hostnames to the traefik LB IP in /etc/hosts.
+# Usage: sudo dev/update-dev-hosts.sh [--remove]
+
+set -e
+[ "$(id -u)" -eq 0 ] || { echo "Re-run with sudo." >&2; exit 1; }
+
+HOSTS_FILE=/etc/hosts
+IP=172.28.255.205
+HOSTS="registry.niployments.local harbor.niployments.local"
+MARKER="# >>> niployments-dev >>>"
+END="# <<< niployments-dev <<<"
+
+sed "/$MARKER/,/$END/d" "$HOSTS_FILE" > "$HOSTS_FILE.new" && mv "$HOSTS_FILE.new" "$HOSTS_FILE"
+
+if [ "${1:-}" = "--remove" ]; then
+  echo "Removed niployments dev entries"
+  exit 0
+fi
+
+{
+  echo "$MARKER"
+  for h in $HOSTS; do echo "$IP	$h"; done
+  echo "$END"
+} >> "$HOSTS_FILE"
+
+echo "Updated $HOSTS_FILE -> $IP"

--- a/dev/update-dev-hosts.sh
+++ b/dev/update-dev-hosts.sh
@@ -1,14 +1,15 @@
 #!/bin/sh
 
-# Map niployments dev hostnames to the traefik LB IP in /etc/hosts.
-# Usage: sudo dev/update-dev-hosts.sh [--remove]
+# Maps hostnames to the traefik LB IP in /etc/hosts.
+# Usage: sudo dev/update-dev-hosts.sh <hostname> [<hostname>...]
+#        sudo dev/update-dev-hosts.sh --remove
 
 set -e
 [ "$(id -u)" -eq 0 ] || { echo "Re-run with sudo." >&2; exit 1; }
+[ $# -gt 0 ] || { echo "usage: $0 <hostname> [<hostname>...] | --remove" >&2; exit 1; }
 
 HOSTS_FILE=/etc/hosts
 IP=172.28.255.205
-HOSTS="registry.niployments.local harbor.niployments.local"
 MARKER="# >>> niployments-dev >>>"
 END="# <<< niployments-dev <<<"
 
@@ -21,7 +22,7 @@ fi
 
 {
   echo "$MARKER"
-  for h in $HOSTS; do echo "$IP	$h"; done
+  for h in "$@"; do echo "$IP	$h"; done
   echo "$END"
 } >> "$HOSTS_FILE"
 

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1764667669,
-        "narHash": "sha256-7WUCZfmqLAssbDqwg9cUDAXrSoXN79eEEq17qhTNM/Y=",
+        "lastModified": 1788881743,
+        "narHash": "sha256-2V9GZGvPfrNzxFozhI9dcqV+c3QdA8YZrvAAzqEB+dI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "418468ac9527e799809c900eda37cbff999199b6",
+        "rev": "d6524aaca2ff07876657ae2b323f24be4874944b",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1788881743,
-        "narHash": "sha256-2V9GZGvPfrNzxFozhI9dcqV+c3QdA8YZrvAAzqEB+dI=",
+        "lastModified": 1764667669,
+        "narHash": "sha256-7WUCZfmqLAssbDqwg9cUDAXrSoXN79eEEq17qhTNM/Y=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d6524aaca2ff07876657ae2b323f24be4874944b",
+        "rev": "418468ac9527e799809c900eda37cbff999199b6",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -24,6 +24,7 @@
             cilium-cli
             kubernetes-helm
             kubectl
+            k9s
           ];
         };
       }

--- a/flake.nix
+++ b/flake.nix
@@ -24,7 +24,6 @@
             cilium-cli
             kubernetes-helm
             kubectl
-            k9s
           ];
         };
       }

--- a/services/test/00-namespace.yaml
+++ b/services/test/00-namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test

--- a/services/test/01-deployment.yaml
+++ b/services/test/01-deployment.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-app
+  namespace: test
+spec:
+  selector:
+    app: test-app
+  ports:
+    - port: 80
+      targetPort: 8080
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-app
+  namespace: test
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test-app
+  template:
+    metadata:
+      labels:
+        app: test-app
+    spec:
+      containers:
+        - name: test-app
+          image: paulbouwer/hello-kubernetes:1.10
+          ports:
+            - containerPort: 8080

--- a/services/test/02-certificate.yaml
+++ b/services/test/02-certificate.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: test-cert
+  namespace: test
+spec:
+  secretName: test-tls
+  dnsNames:
+    - test.niployments.local
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer

--- a/services/test/03-ingress-route.yaml
+++ b/services/test/03-ingress-route.yaml
@@ -1,0 +1,16 @@
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: test-https
+  namespace: test
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: Host(`test.niployments.local`)
+      kind: Rule
+      services:
+        - name: test-app
+          port: 80
+  tls:
+    secretName: test-tls

--- a/services/test/deploy.sh
+++ b/services/test/deploy.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+kubectl apply -f $(dirname $0)/00-namespace.yaml
+kubectl apply -f $(dirname $0)/01-deployment.yaml
+kubectl apply -f $(dirname $0)/02-certificate.yaml
+kubectl apply -f $(dirname $0)/03-ingress-route.yaml

--- a/services/traefik/values-dev.yaml
+++ b/services/traefik/values-dev.yaml
@@ -786,8 +786,8 @@ service:
   # -- Additional entries here will be added to the service spec.
   # -- Cannot contain type, selector or ports entries.
   spec: # {}
-    externalTrafficPolicy: Local
-    # externalTrafficPolicy: Cluster
+    # externalTrafficPolicy: Local
+    externalTrafficPolicy: Cluster
     # loadBalancerIP: "1.2.3.4"
     # clusterIP: "2.3.4.5"
   loadBalancerSourceRanges: []


### PR DESCRIPTION
Closes #139

Makes Traefik actually work in the dev kind cluster so services can be reached over HTTPS through the ingress, and adds a hello-world test service to verify it end-to-end.
 
Steps to test:

1. Make sure you have `kind`, `kubectl`, `cilium-cli` and `helm` installed and available on your path
2. `bash dev/setup-kind-cluster.sh`
3. `bash services/test/deploy.sh`
4. `sudo dev/update-dev-hosts.sh test.niployments.local`. I have added this auxiliary script to automatically add new entries to the `/etc/hosts` file
5. Access https://test.niployments.local/

You'll see a self-signed certificate warning, that's expected in dev (cert-manager uses a self-signed `ClusterIssuer`). Accept the warning to view the page.

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/199aabf4-f2f0-4ba2-9d89-74b52d7023d6" />
